### PR TITLE
Update ThePirateBayAdapter.php

### DIFF
--- a/src/Adapter/ThePirateBayAdapter.php
+++ b/src/Adapter/ThePirateBayAdapter.php
@@ -34,7 +34,6 @@ class ThePirateBayAdapter implements AdapterInterface
      */
     public function search($query='')
     {
-        $query = 'walking';
         try {
             if ($query){
                 $response = $this->httpClient->get('https://thepiratebay.org/search/' . urlencode($query) . '/0/7/0');


### PR DESCRIPTION
The query keeps being defaulted to "Walking" instead of whatever is passed in. Fixed it by removing the line that sets `$query="walking"`